### PR TITLE
Remove Background, Add Marimo to Hypermodern Python

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,5 @@
 source_env_if_exists ~/.envrc.secret
 export TRACE=0
 export VIRTUAL_ENV=."venv"
+source ~/.venv/bin/activate
 layout python

--- a/content/blog/hypermodern-python-2025.md
+++ b/content/blog/hypermodern-python-2025.md
@@ -237,8 +237,6 @@ Static type checking will catch some bugs that many unit test suites won't.  Sta
 
 ## pydantic
 
-TODO mention pydantic 2.0
-
 **[pydantic](https://pydantic-docs.helpmanual.io/) is a tool for organizing and validating data in Python** - it's an alternative to using dictionaries or dataclasses.
 
 pydantic is part of Python's typing revolution - pydantic's ability to create custom types makes writing typed Python a joy.
@@ -504,8 +502,6 @@ shape: (2, 3)
 │ South  ┆ 1200.0    ┆ 1      │
 └────────┴───────────┴────────┘
 ```
-
-*Tip - Polars has no concept of index - a `pl.DataFrame` is a table with each column having the same data type, with no column being more or less special than another.*
 
 *Tip - you can use `pl.DataFrame.to_pandas()` to convert a Polars DataFrame to a Pandas DataFrame. This can be useful to slowly refactor a Pandas based pipeline into a Polars based pipeline.*
 

--- a/content/blog/hypermodern-python-2025.md
+++ b/content/blog/hypermodern-python-2025.md
@@ -14,7 +14,6 @@ slug: hypermodern-python
 {{< img 
     src="/images/hypermodern-2025/hero.png" 
     alt="Terminal in MC Escher style with birds" 
-    caption="Prompt: 'a small computer terminal in the style of MC Escher, birds on the terminal screen, color of Rothko, layout of the painting day and night by MC Escher, colorful and vibrant'. Seed: 42. Created with Stable Diffusion 2."
     caption="{Prompt: 'a small computer terminal in the style of MC Escher, birds on the terminal screen, color of Rothko, layout of the painting day and night by MC Escher, colorful and vibrant', Seed: 42, Creator: Stable Diffusion 2}"
 >}}
 
@@ -695,6 +694,24 @@ logger.add(
 
 *Tip - Loguru supports structured logging of records to JSON via the `logger.add("log.txt", seralize=True)` argument.*
 
+## Marimo
+
+**[Marimo](https://marimo.io) is a Python notebook editor and format** - it's an alternative to Jupyter Lab and the JSON Jupyter notebook file format.
+
+Marimo offers multiple improvements over older ways of writing Python notebooks:
+
+- **Safer** - Marimo notebook cells are executed based on variable references rather than order,
+- **Reactive** - Marimo's safety allows it to be reactive - cells are re-run when their dependencies change,
+- **Development Experience** - Marimo offers many quality of life features for developers,
+- **Interactive** - Marimo offers an interactive, web-app like experience.
+
+Marimo notebooks are stored as pure Python files, which means that:
+
+- Git diffs are meaningful,
+- The notebook can be executed as a script.
+
+*Tip - Marimo integrates with GitHub Copilot and Ruff code formatting.*
+
 ## Summary
 
 The **2025 Hypermodern Python Toolbox** is:
@@ -709,4 +726,4 @@ The **2025 Hypermodern Python Toolbox** is:
 - [Polars](https://docs.pola.rs/) for manipulating tabular data,
 - [DuckDB](https://duckdb.org/docs/) for a single file, analytical SQL database,
 - [Loguru](https://loguru.readthedocs.io/en/stable/) for logging.
-
+- [Marimo](https://docs.marimo.io/) for reactive Python notebooks.

--- a/content/blog/hypermodern-python-2025.md
+++ b/content/blog/hypermodern-python-2025.md
@@ -705,10 +705,31 @@ Marimo offers multiple improvements over older ways of writing Python notebooks:
 - **Development Experience** - Marimo offers many quality of life features for developers,
 - **Interactive** - Marimo offers an interactive, web-app like experience.
 
-Marimo notebooks are stored as pure Python files, which means that:
+Marimo notebooks are stored as pure Python files, which means that:Git diffs are meaningful, and the notebook can be executed as a script.
 
-- Git diffs are meaningful,
-- The notebook can be executed as a script.
+Below is an example of the Marimo notebook format:
+
+```python { title = "marimo.py" }
+import marimo
+
+__generated_with = "0.10.12"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import pandas as pd
+
+    def func():
+        return None
+
+    print("hello")
+    return func, pd
+
+
+if __name__ == "__main__":
+    app.run()
+```
 
 *Tip - Marimo integrates with GitHub Copilot and Ruff code formatting.*
 

--- a/content/blog/hypermodern-python-2025.md
+++ b/content/blog/hypermodern-python-2025.md
@@ -701,9 +701,10 @@ logger.add(
 Marimo offers multiple improvements over older ways of writing Python notebooks:
 
 - **Safer** - Marimo notebook cells are executed based on variable references rather than order,
-- **Reactive** - Marimo's safety allows it to be reactive - cells are re-run when their dependencies change,
 - **Development Experience** - Marimo offers many quality of life features for developers,
 - **Interactive** - Marimo offers an interactive, web-app like experience.
+
+Marimo also offers the feature of being reactive - cells can be re-executed when their inputs change.  This can be a double-edged sword for some notebooks, where changing a call can cause side effects like querying APIs or databases.
 
 Marimo notebooks are stored as pure Python files, which means that:Git diffs are meaningful, and the notebook can be executed as a script.
 

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <div class="container mx-auto p-4 min-h-[calc(100vh-8rem)] flex items-center justify-center">
-    <div class="bg-gray-100 p-8 text-center max-w-2xl">
+    <div class="p-8 text-center max-w-2xl">
         <h1 class="text-6xl font-bold text-gray-800 mb-4">404</h1>
         <h2 class="text-2xl font-semibold text-gray-700 mb-6">Page Not Found</h2>
         <p class="text-gray-600 mb-8">Oops! The page you're looking for doesn't exist or has been moved.</p>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -50,11 +50,17 @@
     </head>
     <body class="font-sans leading-normal">
         <header class="bg-gray-800 sticky top-0 z-50 p-1 pt-2">
-            <a href="/"
-               class="group inline-flex items-center rounded-full hover:bg-white hover:shadow-lg hover:-translate-y-1 transition-all duration-200">
-                <img src="/logos/light.svg" alt="Site Logo" width="50" height="50">
-                <h1 class="text-xl font-bold text-white group-hover:text-gray-800 ml-2 mr-4">{{ .Site.Title }}</h1>
-            </a>
+            <div class="container mx-auto flex justify-between items-center">
+                <a href="/"
+                   class="inline-flex items-center pl-0 pr-3 py-0 rounded-lg hover:bg-emerald-500 hover:text-emerald-50 hover:-translate-y-1 hover:shadow-lg transition-all duration-200">
+                    <img src="/logos/light.svg" alt="Site Logo" width="50" height="50">
+                    <h1 class="text-xl font-bold text-white ml-2">{{ .Site.Title }}</h1>
+                </a>
+                <a href="/competencies/"
+                   class="text-white font-semibold px-4 py-2 rounded-lg hover:bg-emerald-500 hover:text-emerald-50 hover:-translate-y-1 hover:shadow-lg transition-all duration-200">
+                    Competencies
+                </a>
+            </div>
         </header>
         {{ block "main" . }}{{ end }}
     </body>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="container mx-auto p-4 flex flex-col gap-4 min-h-[calc(100vh-8rem)]"
      data-pagefind-ignore>
-    <div class="bg-gray-100 p-6 rounded-lg">
+    <div class="p-6 rounded-lg">
         <h1 class="text-3xl font-bold mb-6">{{ .Title }}</h1>
         <div class="grid gap-4 pl-4">{{ range .Pages.ByTitle }} {{ partial "lesson-card.html" . }} {{ end }}</div>
     </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -3,14 +3,14 @@
      {{ if in .File.Path "blog" }}
      data-pagefind-ignore
      {{ end }}>
-    <div class="hidden xl:block flex-1 max-w-64 bg-gray-100 p-2 rounded-lg">{{ partial "left-sidebar.html" . }}</div>
-    <div class="flex-1 max-w-3xl bg-gray-100 p-2 rounded-lg ">
+    <div class="hidden xl:block flex-1 max-w-64 p-2 rounded-lg">{{ partial "left-sidebar.html" . }}</div>
+    <div class="flex-1 max-w-3xl p-2 rounded-lg ">
         <h1 class="text-3xl font-bold mb-6">{{ .Title }}</h1>
         <div class="prose max-w-none [&_h1]:scroll-mt-20 [&_h2]:scroll-mt-20 [&_h3]:scroll-mt-20 [&_h4]:scroll-mt-20">
             {{ .Content }}
         </div>
     </div>
-    <div class="hidden lg:block flex-1 max-w-64 bg-gray-100 p-2 rounded-lg sticky top-20 h-fit">
+    <div class="hidden lg:block flex-1 max-w-64 p-2 rounded-lg sticky top-20 h-fit">
         {{ partial "right-sidebar.html" . }}
     </div>
 </div>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="container mx-auto p-4 flex flex-col gap-4 min-h-[calc(100vh-8rem)]"
      data-pagefind-ignore>
-    <div class="bg-gray-100 p-6 rounded-lg">
+    <div class="p-6 rounded-lg">
         <h1 class="text-3xl font-bold mb-6">{{ .Title }}</h1>
         {{ $pages := .Pages.ByDate.Reverse }}
         {{ $posts := $pages.GroupByDate "2006" }}

--- a/layouts/competencies/list.html
+++ b/layouts/competencies/list.html
@@ -9,7 +9,26 @@
                 {{ .Page.Title }}
                 <span class="text-sm font-normal text-gray-600">({{ .Count }} lessons)</span>
             </h2>
-            <div class="grid gap-4 pl-4">{{ range .Pages.ByTitle }} {{ partial "lesson-card.html" . }} {{ end }}</div>
+            <div class="grid gap-4 pl-4">
+                {{ range .Pages.ByTitle }}
+                <div class="group">
+                    <a href="{{ .RelPermalink }}"
+                       class="block p-4 bg-white rounded-lg shadow-sm hover:-translate-y-1 hover:shadow-lg hover:bg-gray-800 hover:text-white transition-all duration-200">
+                        <h3 class="text-lg font-medium mb-2">{{ .Title }}</h3>
+                        {{ with .Params.summary }}
+                        <p class="text-sm opacity-75 group-hover:text-white/75">{{ . }}</p>
+                        {{ end }}
+                        <div class="mt-2 flex flex-wrap gap-2">
+                            {{ range .Params.competencies }}
+                            <span class="px-2 py-1 text-xs rounded bg-gray-100 text-gray-700 group-hover:bg-emerald-500 group-hover:text-emerald-50 transition-colors duration-200">
+                                {{ . }}
+                            </span>
+                            {{ end }}
+                        </div>
+                    </a>
+                </div>
+                {{ end }}
+            </div>
         </div>
         {{ end }}
     </div>

--- a/layouts/competencies/list.html
+++ b/layouts/competencies/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="container mx-auto p-4 flex flex-col gap-4 min-h-[calc(100vh-8rem)]"
      data-pagefind-ignore>
-    <div class="bg-gray-100 p-6 rounded-lg">
+    <div class="p-6 rounded-lg">
         <h1 class="text-3xl font-bold mb-6">{{ .Title }}</h1>
         {{ range .Data.Terms.Alphabetical }}
         <div class="mb-8">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class="container mx-auto p-4 pt-6 flex flex-row justify-center gap-4 min-h-[calc(100vh-8rem)]">
-    <div class="flex-1 max-w-64 bg-gray-100 p-2 rounded-lg">{{ partial "left-sidebar.html" . }}</div>
-    <div class="flex-1 max-w-3xl bg-gray-100 p-2 rounded-lg ">
+    <div class="flex-1 max-w-64 p-2 rounded-lg">{{ partial "left-sidebar.html" . }}</div>
+    <div class="flex-1 max-w-3xl p-2 rounded-lg ">
         <h2 class="text-3xl font-bold mb-6">{{ .Title }}</h2>
         <div class="prose prose-blue max-w-none [&_h1]:scroll-mt-20 [&_h2]:scroll-mt-20 [&_h3]:scroll-mt-20 [&_h4]:scroll-mt-20">
             {{ .Content }}

--- a/layouts/partials/left-sidebar.html
+++ b/layouts/partials/left-sidebar.html
@@ -1,4 +1,4 @@
-<div class="flex-1 max-w-64 bg-gray-100 p-2 rounded-lg sticky top-20 h-fit">
+<div class="flex-1 max-w-64 p-2 rounded-lg sticky top-20 h-fit">
     {{ $mainSections := slice
     (dict "title" "Blog" "url" "/blog/")
     (dict "title" "Competencies" "url" "/competencies/")


### PR DESCRIPTION
Refactor:
- remove `bg-gray-100` background,
- make `/competencies` page consistent with blog page on hover.

Content:
- add Marimo section to Hypermodern Python 2025,
- cleanup Hypermodern Python 2025.