### PR TITLE
Fixed a Spelling Mistake

### DIFF
--- a/content/lessons/git.md
+++ b/content/lessons/git.md
@@ -333,7 +333,7 @@ Every time a change is made and saved in Git, it is recorded in the project's hi
 
 This keep everything approach means that anything you commit to a repository will be there forever.  This is important to remember when working with secrets (like AWS keys) or with large datasets.
 
-## Repoitories
+## Repositories
 
 ### Local Repositories
 


### PR DESCRIPTION
### What this PR does
Fixed the spelling mistake "Repoitories" --> "Repositories".

### Related Issues 
N/A

### Other Comments
I haven't checked anything else out for spelling, just wanted to give this a go as I've never done it before.

### How to test
I know you're a nvim user so just search for the incorrect string and check it isn't there anymore.