### PR TITLE
Redirect all traffic to adgefficiency.com

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,1 @@
+/*  https://adgefficiency.com/:splat  301!


### PR DESCRIPTION
## Summary

- Adds a Netlify `_redirects` file to 301 redirect all paths from data-science-south to `adgefficiency.com` with path preservation
- Uses `/:splat` to preserve the original URL path and `!` to force the redirect even when matching files exist

## Test plan

- [ ] Verify `_redirects` file is served at site root after deploy
- [ ] Confirm root domain redirects to `https://adgefficiency.com/`
- [ ] Confirm subpaths like `/lessons/python` redirect to `https://adgefficiency.com/lessons/python`